### PR TITLE
Parent Locking

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -48,21 +48,16 @@ const assemble = (context: any = null) => {
  * @name filterTextNodes
  *
  * @param {Array} selection The resulting array of text nodes.
- * @param {boolean} includeLocked Include locked nodes in the returned results (`true`)
- * or omit them (`false`).
  *
  * @returns {Array} The resulting array of text nodes.
  */
-const filterTextNodes = (
-  selection: Array<any>,
-  includeLocked: boolean = false,
-): Array<TextNode> => {
+const filterTextNodes = (selection: Array<any>): Array<TextNode> => {
   const consolidatedSelection: Array<SceneNode | PageNode> = selection;
 
   // retrieve selection of text nodes and filter for unlocked
   const textNodes: Array<TextNode> = new Crawler(
     { for: consolidatedSelection },
-  ).text(includeLocked);
+  ).text();
 
   return textNodes;
 };
@@ -729,8 +724,7 @@ export default class App {
    */
   async commitText(sessionKey: number) {
     const { messenger, selection } = assemble(figma);
-    const includeLocked: boolean = false;
-    const textNodes: Array<TextNode> = filterTextNodes(selection, includeLocked);
+    const textNodes: Array<TextNode> = filterTextNodes(selection);
 
     /**
      * @description Applies a `Painter` instance to each node in an array, updating the text.
@@ -789,9 +783,7 @@ export default class App {
         : '❌ This text layer contains a missing font';
       messenger.log('Text node(s) contained missing fonts');
     } else {
-      toastErrorMessage = includeLocked
-        ? '❌ You need to select at least one text layer'
-        : '❌ You need to select at least one unlocked text layer';
+      toastErrorMessage = '❌ You need to select at least one text layer';
       messenger.log('No text nodes were selected/found');
     }
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -270,7 +270,7 @@ export default class App {
    */
   static refreshGUI(sessionKey: number) {
     const { messenger, selection } = assemble(figma);
-    const textNodes: Array<TextNode> = filterTextNodes(selection, false);
+    const textNodes: Array<TextNode> = filterTextNodes(selection);
     const textNodesCount = textNodes.length;
 
     // set array of data with information from each text node
@@ -385,7 +385,7 @@ export default class App {
      * @returns {Object} The text node (`TextNode`) retrieved.
      */
     const retrieveTextNode = (): TextNode => {
-      const textNodes: Array<TextNode> = filterTextNodes(selection, false);
+      const textNodes: Array<TextNode> = filterTextNodes(selection);
 
       const index = 0;
       const textNodesToUpdate: Array<TextNode> = textNodes.filter(
@@ -564,7 +564,7 @@ export default class App {
    */
   static remixAll(sessionKey: number): void {
     const { messenger, selection } = assemble(figma);
-    const textNodes: Array<TextNode> = filterTextNodes(selection, false);
+    const textNodes: Array<TextNode> = filterTextNodes(selection);
 
     // iterate through each selected layer and apply the `remix` action
     textNodes.forEach((textNode: TextNode) => App.actOnNode('remix', { id: textNode.id }, sessionKey));
@@ -598,7 +598,7 @@ export default class App {
   quickRandomize(assignment: string, sessionKey: number): void {
     const { messenger, selection } = assemble(figma);
     const textProposedKey: string = `${DATA_KEYS.textProposed}-${sessionKey}`;
-    const textNodes: Array<TextNode> = filterTextNodes(selection, false);
+    const textNodes: Array<TextNode> = filterTextNodes(selection);
 
     // iterate through each selected layer and apply the `remix` action
     textNodes.forEach((textNode: TextNode) => {
@@ -665,7 +665,7 @@ export default class App {
    */
   quickAssign(assignment: string): void {
     const { messenger, selection } = assemble(figma);
-    const textNodes: Array<TextNode> = filterTextNodes(selection, false);
+    const textNodes: Array<TextNode> = filterTextNodes(selection);
 
     // iterate through each selected layer and apply the `remix` action
     textNodes.forEach((textNode: TextNode) => {

--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -50,6 +50,7 @@ export default class Crawler {
         && node.type !== CONTAINER_NODE_TYPES.component
         && node.type !== CONTAINER_NODE_TYPES.instance
         && node.visible
+        && !node.locked
       ) {
         // non-frame or -group nodes get added to the final selection
         flatSelection.push(node);
@@ -58,9 +59,9 @@ export default class Crawler {
 
         // set initial holding array and add first level of children
         let innerLayers = [];
-        if (node.visible) {
+        if (node.visible && !node.locked) {
           node.children.forEach((child) => {
-            if (child.visible) {
+            if (child.visible && !node.locked) {
               innerLayers.push(child);
             }
           });
@@ -85,6 +86,7 @@ export default class Crawler {
               id: string,
               type: string,
               visible: boolean,
+              locked: boolean,
             },
           ) => {
             if (
@@ -93,12 +95,13 @@ export default class Crawler {
               && innerLayer.type !== CONTAINER_NODE_TYPES.component
               && innerLayer.type !== CONTAINER_NODE_TYPES.instance
               && innerLayer.visible
+              && !innerLayer.locked
             ) {
               // non-frame or -group nodes get added to the final selection
               flatSelection.push(innerLayer);
-            } else if (innerLayer.visible) {
+            } else if (innerLayer.visible && !innerLayer.locked) {
               innerLayer.children.forEach((child) => {
-                if (child.visible) {
+                if (child.visible && !child.locked) {
                   innerLayers.push(child);
                 }
               });
@@ -175,7 +178,7 @@ export default class Crawler {
     // iterate through components to find additional text nodes
     const componentNodes: Array<ComponentNode | InstanceNode> = nodes.filter(
       (node: SceneNode) => (
-        (node.type === 'COMPONENT' || node.type === 'INSTANCE') && node.visible
+        (node.type === 'COMPONENT' || node.type === 'INSTANCE') && node.visible && !node.locked
       ),
     );
     if (componentNodes) {

--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -162,17 +162,15 @@ export default class Crawler {
    *
    * @kind function
    * @name text
-   * @param {boolean} includeLocked Determines whether or not locked nodes are included
-   * in the selection.
    *
    * @returns {Array} All TextNode items in an array.
    */
-  text(includeLocked: boolean = false): Array<TextNode> {
+  text(): Array<TextNode> {
     // start with flattened selection of all nodes, ordered by position on the artboard
     const nodes = this.allSorted();
 
     // filter and retain immediate text nodes
-    let textNodes: Array<TextNode> = nodes.filter((node: SceneNode) => node.type === 'TEXT');
+    const textNodes: Array<TextNode> = nodes.filter((node: SceneNode) => node.type === 'TEXT');
 
     // iterate through components to find additional text nodes
     const componentNodes: Array<ComponentNode | InstanceNode> = nodes.filter(
@@ -195,11 +193,6 @@ export default class Crawler {
           innerTextNodes.forEach(innerTextNode => textNodes.push(innerTextNode));
         }
       });
-    }
-
-    // remove locked text nodes, if necessary
-    if (!includeLocked) {
-      textNodes = textNodes.filter((node: TextNode) => !node.locked);
     }
 
     return textNodes;


### PR DESCRIPTION
In `Crawler`, ignore layers that have locked parents (unless they selected directly). This is the behavior we are already using for layer visibility, but now also applied to layer locking.